### PR TITLE
Support to retrieve real hostname where Nginx is running when properl…

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,12 @@ location /nginx_status {
     # do not log status polling
     access_log off;
  
-    # restrict access to local only
+    # restrict access to local only (if not remote)
     allow 127.0.0.1;
     deny all;
+
+    # return hostname in response as a header
+    add_header Hostname $hostname;
    }
 } 
 
@@ -1180,6 +1183,25 @@ function poll(cb) {
 }
 
 
+// get the real hostname where Nginx is running, if defined
+function init() {
+        _request
+                .get(_param.url,
+                     _httpOptions,
+                     function(err, resp, body) {
+			 if (resp.statusCode === 200) {
+                         	if (resp.statusCode === 200 && typeof resp.headers['hostname'] !== 'undefined' && resp.headers['hostname']) {
+                               		_param.source = resp.headers['hostname'];
+                                	console.log('_param.source redefined:');
+                                	console.log(_param.source);
+                         	} else {
+					console.log('hostname header is undefined');
+				} 
+			 }
+                         poll();
+                     });
+}
+
 /* MAIN PROCESS */
 
 console.info("----------------------------------------------");
@@ -1189,7 +1211,8 @@ console.info("----------------------------------------------");
 
 createATCConfig();
 
-poll();
+init();
+//poll();
 	
 
 


### PR DESCRIPTION
Current version of the fieldpack is designed to run locally.

When fieldpak is run remotely or Nginx runs in a docker container and exposed as a service, fieldpack returns Nginx's hostname as the hostname where fieldpack is running.

By adding a Hostname header as part of the nginx_status location, fieldpack can always resolve the proper hostname where Nginx is running.